### PR TITLE
Fix CustomLink rendering

### DIFF
--- a/components/CustomLink.js
+++ b/components/CustomLink.js
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 
-export default function CustomLink({ as, href, ...otherProps }) {
-  return <>
+export default function CustomLink({ as, href, children, ...otherProps }) {
+  return (
     <Link as={as} href={href} {...otherProps}>
-
+      {children}
     </Link>
-  </>;
+  );
 }


### PR DESCRIPTION
## Summary
- ensure `CustomLink` renders its child content so MDX links show text

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cab2be0083339cb56afd83ae0a76